### PR TITLE
Add CTest definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
 - if [[ $TRAVIS_OS_NAME == osx ]]; then brew update; fi
 - eval "${MATRIX_EVAL}"
 - mkdir build && cd build
-- cmake .. -Werror=dev -DRS_COVERAGE=$COVERAGE
+- cmake .. -Werror=dev -DRS_COVERAGE=$COVERAGE -DBUILD_TESTING=1
 
 script:
 - make -j 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,5 +7,9 @@ include(${CMAKE_SOURCE_DIR}/cmake/utility.cmake)
 
 # TODO: Installation.
 
+if(BUILD_TESTING)
+	enable_testing()
+endif()
+
 add_subdirectory(test)
 add_subdirectory(benchmark)

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ git clone --recurse-submodules https://github.com/boyerjohn/rapidstring
 cd rapidstring
 mkdir build
 cd build
-cmake ..
+cmake .. -DBUILD_TESTING=1
 cmake --build .
 ```
 The build will default to debug mode. To compile in release mode, pass this flag `-DCMAKE_BUILD_TYPE=Release` to the cmake generation command. The test and benchmark executables will be in their respective folders.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ install:
 before_build:
   - mkdir build
   - cd build
-  - cmake .. -G "Visual Studio 15 2017 Win64" -Werror=dev
+  - cmake .. -G "Visual Studio 15 2017 Win64" -DBUILD_TESTING=1 -Werror=dev
 
 test_script:
   - cd C:\Projects\rapidstring\build\test\%CONFIGURATION%

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,25 +1,35 @@
 project(rapidstring_test LANGUAGES CXX)
-add_executable(rapidstring_test
-	src/capacity.cpp
-	src/concat.cpp
-	src/construct.cpp
-	src/copy.cpp
-	src/main.cpp
-	src/modifiers.cpp
-)
 
-add_subdirectory(lib/Catch2)
-target_link_libraries(rapidstring_test PRIVATE rapidstring Catch2::Catch)
-target_compile_features(rapidstring_test PRIVATE cxx_std_11)
-target_compile_warnings(rapidstring_test)
+if(BUILD_TESTING)
+	enable_testing()
 
-if(RS_COVERAGE)
-	target_compile_definitions(rapidstring_test PRIVATE RS_NOINLINE)
-	target_link_libraries(rapidstring_test PRIVATE gcov)
-	target_compile_options(rapidstring_test
-		PRIVATE
-			-fprofile-arcs
-			-ftest-coverage
-			-Wno-unused-function
+	add_executable(rapidstring_test
+		src/capacity.cpp
+		src/concat.cpp
+		src/construct.cpp
+		src/copy.cpp
+		src/main.cpp
+		src/modifiers.cpp
+	)
+
+	add_subdirectory(lib/Catch2)
+	target_link_libraries(rapidstring_test PRIVATE rapidstring Catch2::Catch)
+	target_compile_features(rapidstring_test PRIVATE cxx_std_11)
+	target_compile_warnings(rapidstring_test)
+
+	if(RS_COVERAGE)
+		target_compile_definitions(rapidstring_test PRIVATE RS_NOINLINE)
+		target_link_libraries(rapidstring_test PRIVATE gcov)
+		target_compile_options(rapidstring_test
+			PRIVATE
+				-fprofile-arcs
+				-ftest-coverage
+				-Wno-unused-function
+		)
+	endif()
+
+	add_test(
+		NAME rapidstring-test
+		COMMAND "$<TARGET_FILE:rapidstring_test>" --success --reporter compact
 	)
 endif()


### PR DESCRIPTION
This allows tests to be grouped into a larger project using `ctest`.

To see how this works, do:

```console
$ cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=On
```

Then build. You can run tests using the following:

```console
$ ctest
$ ctest -VV      # for high verbosity; otherwise tests are reduced to pass/fail
```

Everything used here is 100% CMake testing best practices - the `BUILD_TESTING` variable is considered [standard](https://cmake.org/cmake/help/v3.0/module/CTest.html).